### PR TITLE
Error handling and query results count.

### DIFF
--- a/postgres.js
+++ b/postgres.js
@@ -136,7 +136,7 @@ module.exports = (RED) => {
           }
           
           var queryError = false;
-          var queryCounts = [];
+          var _queryCounts = [];
           for (let i=0; i < queries.length; ++i) {
             try {
               const { query, params = {}, output = false } = queries[i];
@@ -144,22 +144,22 @@ module.exports = (RED) => {
   
               if (output && node.output) {
                 // Save count of rows returned by a query
-                queryCounts.push(result.rows.length);
+                _queryCounts.push(result.rows.length);
                 outMsg.payload = outMsg.payload.concat(result.rows);
               }
             } catch (e) {
               // Assign -1 to result count to indicate query failure
-              queryCounts.push(-1);
+              _queryCounts.push(-1);
               handleError(e, msg);
             } finally {
-              msg.queryCounts = queryCounts;
+              msg._queryCounts = _queryCounts;
             }
           }
           client.release();
 
           if (node.output) {
             // Save count of rows in payload
-            outMsg.queryCounts = queryCounts;
+            outMsg._queryCounts = _queryCounts;
             node.send(outMsg);
           }
         } catch(e) {

--- a/postgres.js
+++ b/postgres.js
@@ -152,7 +152,7 @@ module.exports = (RED) => {
 
             if (node.output) {
               // Save count of rows in payload
-              outMsg.payload.queryCounts = queryCounts;
+              outMsg.payload = {"queryCounts" : queryCounts};
               node.send(outMsg);
             }
           } catch(e) {

--- a/postgres.js
+++ b/postgres.js
@@ -152,7 +152,7 @@ module.exports = (RED) => {
 
             if (node.output) {
               // Save count of rows in payload
-              outMsg.payload = {"queryCounts" : queryCounts};
+              outMsg.queryCounts = queryCounts;
               node.send(outMsg);
             }
           } catch(e) {

--- a/postgres.js
+++ b/postgres.js
@@ -107,7 +107,10 @@ module.exports = (RED) => {
       };
 
       var handleError = (err, msg) => {
-        node.error(err);
+        //node.error(msg); This line is committed and edited to take the msg object also.
+        // This allows the error to be caught with a Catch node.
+        // Refer - https://iot.stackexchange.com/a/3144/185
+        node.error(err, msg);
         console.log(err);
         console.log(msg.payload);
       };

--- a/postgres.js
+++ b/postgres.js
@@ -137,16 +137,22 @@ module.exports = (RED) => {
           }
 
           try {
+            // Count of rows returned by a query
+            var queryCounts = [];
             for (let i=0; i < queries.length; ++i) {
               const { query, params = {}, output = false } = queries[i];
               const result = await client.query(query, params);
 
               if (output && node.output) {
+                // Save count of rows returned by a query
+                queryCounts.push(result.rows.length);
                 outMsg.payload = outMsg.payload.concat(result.rows);
               }
             }
 
             if (node.output) {
+              // Save count of rows in payload
+              outMsg.payload.queryCounts = queryCounts;
               node.send(outMsg);
             }
           } catch(e) {


### PR DESCRIPTION
Hi,
This pull request addresses the following:

- Error handling
- Query results count

## Error handling
If the node encounters an error, then error is not available for catching by a Catch node. This is because, the `node.error` is not emitting the message as well. See discussion [here](https://iot.stackexchange.com/q/3138/185).

## Count of results
When sending multiple queries to this node, the result does not differentiate between the results from different queries. Specifically, it is hard to know, if a query returned any result at all. See discussion [here](https://discourse.nodered.org/t/steps-to-modify-a-node-red-contrib-node/1313).

## Files changed

- `postgres.js`

## Node output
With this change, `msg.payload` will *not* change. However, there is an additional field named as `_queryCounts` that is an array of counts of rows returned by each query. 

## Test
Import the following flow into the canvas. To test, click on the button of the Inject node to start the flow. You should see the response similar to one pasted below.

### Flow with modified node

```json
[
  {
    "id": "a5281d45.cd5f38",
    "type": "tab",
    "label": "Flow 1",
    "disabled": false,
    "info": ""
  },
  {
    "id": "c9fee356.432a48",
    "type": "inject",
    "z": "a5281d45.cd5f38",
    "name": "Test",
    "topic": "",
    "payload": "Test",
    "payloadType": "str",
    "repeat": "",
    "crontab": "",
    "once": false,
    "onceDelay": 0.1,
    "x": 110,
    "y": 280,
    "wires": [
      [
        "48df46a8.18f108"
      ]
    ]
  },
  {
    "id": "48df46a8.18f108",
    "type": "function",
    "z": "a5281d45.cd5f38",
    "name": "DemoQueries",
    "func": "var select1 = {\n    \"query\" : \"SELECT * FROM pg_tablespace;\",\n    \"params\" : [],\n    \"output\" : true\n};\nvar select2 = {\n    \"query\" : \"SELECT * FROM pg_tablespace where spcname='does not exist';\",\n    \"params\" : [],\n    \"output\" : true\n};\nvar select3 = {\n    \"query\" : \"SELECT * FROM pg_does_not_exist;\",\n    \"params\" : [],\n    \"output\" : true\n};\nvar select4 = {\n    \"query\" : \"SELECT CURRENT_TIMESTAMP;\",\n    \"params\" : [],\n    \"output\" : true\n};\n//\nmsg.payload = [select1, select2, select3, select4];\nreturn msg;",
    "outputs": 1,
    "noerr": 0,
    "x": 300,
    "y": 280,
    "wires": [
      [
        "602818ee.9007b"
      ]
    ]
  },
  {
    "id": "602818ee.9007b",
    "type": "postgres",
    "z": "a5281d45.cd5f38",
    "postgresdb": "bf82a294.d62fb8",
    "name": "DBQuery",
    "output": true,
    "outputs": 1,
    "x": 500,
    "y": 280,
    "wires": [
      [
        "81904e66.fba"
      ]
    ]
  },
  {
    "id": "81904e66.fba",
    "type": "debug",
    "z": "a5281d45.cd5f38",
    "name": "QueryOutput",
    "active": true,
    "tosidebar": true,
    "console": false,
    "tostatus": false,
    "complete": "true",
    "x": 690,
    "y": 280,
    "wires": []
  },
  {
    "id": "28e80b0.e6483f6",
    "type": "catch",
    "z": "a5281d45.cd5f38",
    "name": "CatchDbError",
    "scope": [
      "602818ee.9007b"
    ],
    "x": 110,
    "y": 380,
    "wires": [
      [
        "42209308.791e84"
      ]
    ]
  },
  {
    "id": "42209308.791e84",
    "type": "debug",
    "z": "a5281d45.cd5f38",
    "name": "Errors",
    "active": true,
    "tosidebar": true,
    "console": false,
    "tostatus": false,
    "complete": "true",
    "x": 670,
    "y": 380,
    "wires": []
  },
  {
    "id": "bf82a294.d62fb8",
    "type": "postgresdb",
    "z": "",
    "hostname": "localhost",
    "port": "5432",
    "db": "demo_db",
    "ssl": false
  }
]
```

### Response

#### Query output

```json
{
  "_msgid": "be29e1db.909d4",
  "topic": "",
  "payload": [
    {
      "spcname": "pg_default",
      "spcowner": 10,
      "spcacl": null,
      "spcoptions": null
    },
    {
      "spcname": "pg_global",
      "spcowner": 10,
      "spcacl": null,
      "spcoptions": null
    },
    {
      "spcname": "dvcdata",
      "spcowner": 16384,
      "spcacl": null,
      "spcoptions": null
    },
    {
      "spcname": "appdata",
      "spcowner": 16384,
      "spcacl": null,
      "spcoptions": null
    },
    {
      "current_timestamp": "2018-07-07T14:12:26.709Z"
    }
  ],
  "_queryCounts": [
    4,
    0,
    -1,
    1
  ]
}
```

#### Error output
```json
{
  "_msgid": "be29e1db.909d4",
  "topic": "",
  "payload": [
    {
      "query": "SELECT * FROM pg_tablespace;",
      "params": [],
      "output": true
    },
    {
      "query": "SELECT * FROM pg_tablespace where spcname='does not exist';",
      "params": [],
      "output": true
    },
    {
      "query": "SELECT * FROM pg_does_not_exist;",
      "params": [],
      "output": true
    },
    {
      "query": "SELECT CURRENT_TIMESTAMP;",
      "params": [],
      "output": true
    }
  ],
  "_queryCounts": [
    4,
    0,
    -1
  ],
  "error": {
    "message": "error: relation \"pg_does_not_exist\" does not exist",
    "source": {
      "id": "602818ee.9007b",
      "type": "postgres",
      "name": "DBQuery",
      "count": 1
    },
    "stack": "error: relation \"pg_does_not_exist\" does not exist\n    at Connection.parseE (/home/ubuntu/node_modules/pg/lib/connection.js:553:11)\n    at Connection.parseMessage (/home/ubuntu/node_modules/pg/lib/connection.js:378:19)\n    at Socket.<anonymous> (/home/ubuntu/node_modules/pg/lib/connection.js:119:22)\n    at emitOne (events.js:116:13)\n    at Socket.emit (events.js:211:7)\n    at addChunk (_stream_readable.js:263:12)\n    at readableAddChunk (_stream_readable.js:250:11)\n    at Socket.Readable.push (_stream_readable.js:208:10)\n    at TCP.onread (net.js:597:20)"
  }
}
```