### PR TITLE
Fix broken pg support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.2.0",
     "description": "A Node-RED node to query PostgreSql, with multi-query support",
     "dependencies": {
-        "pg": "~7.4.1",
+        "pg": "~8.7.1",
         "node-postgres-named": "^2.4.1",
         "querystring": "^0.2.0"
     },


### PR DESCRIPTION
See issue https://github.com/BruceFletcher/node-red-contrib-postgres-multi/issues/9

For an interim workaround you can manually deploy the node package in your node-red environment like this:

    cd /data/  (or wherever the directory is where your flows live)
    npm install git+https://github.com/kartoza/node-red-contrib-postgres-multi.git
    

Screenshot showing node-red working with the PG node working when my patch is applied: 

![image](https://user-images.githubusercontent.com/178003/132074185-94625e20-286c-41e3-9dcc-b1c6cb2dc834.png)
